### PR TITLE
Add MinGW cross-compile support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,9 @@ else()
   target_link_libraries(browserselector PRIVATE ${FLTK_LIBRARIES})
 endif()
 
+if(WIN32)
+  target_link_libraries(browserselector PRIVATE shell32)
+endif()
+
 target_compile_features(browserselector PRIVATE cxx_std_17)
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,25 @@ project specification.
 
 ## Build
 
+### Linux
+
 ```sh
 cmake -S . -B build
 cmake --build build
+```
+
+### Windows (cross-compile from Linux using MinGW)
+
+Install the `mingw-w64` toolchain along with Windows builds of FLTK and
+`nlohmann_json`. A sample toolchain file is provided in
+`cmake/toolchain-mingw.cmake`. Configure with it and point `FLTK_DIR` to the
+Windows FLTK CMake package:
+
+```sh
+# example using the default x86_64-w64-mingw32 triplet
+cmake -S . -B build-win -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-mingw.cmake \
+      -DFLTK_DIR=/usr/x86_64-w64-mingw32/lib/cmake/fltk
+cmake --build build-win
 ```
 
 ## Usage

--- a/cmake/toolchain-mingw.cmake
+++ b/cmake/toolchain-mingw.cmake
@@ -1,0 +1,18 @@
+# CMake toolchain file for cross-compiling to Windows using MinGW-w64
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_VERSION 1)
+
+# Adjust the triplet if targeting 32-bit Windows
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+# Where to look for the target environment. Update if your cross
+# compiler is installed elsewhere.
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
## Summary
- Link `shell32` when targeting Windows
- Add MinGW toolchain file for cross-compiling on Linux
- Document MinGW cross-compilation steps in README

## Testing
- `cmake -S . -B build` *(fails: Could NOT find FLTK)*
